### PR TITLE
Terraform 0.8.x compatibility updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 ## Unreleased
 
-## ???
+## 0.1.0
+
+#### BREAKING CHANGES:
+
+- Removed `\` backslash escapes. Breaks compatibility with Terraform versions < 0.8.0
+
+#### IMPROVEMENTS:
 
 - Feature: Automatically push instance's subnet route into `server.conf`
 - export `zone_id`, `dns_name` from aws_elb
 - Fix the 4 subnet fixed mapping
 - Fill in some examples
+- Update modules to use terraform 0.8.x syntax
 
 ## 0.0.8
 

--- a/certs/main.tf
+++ b/certs/main.tf
@@ -197,7 +197,7 @@ data "template_file" "user_data" {
 
 ## Creates auto scaling cluster
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.2.0//group"
+  source = "github.com/WhistleLabs/terraform-aws-asg?ref=v0.2.1//group"
 
   # Resource tags
   stack_item_label    = "${var.stack_item_label}"

--- a/certs/main.tf
+++ b/certs/main.tf
@@ -35,8 +35,8 @@ resource "aws_iam_role_policy" "s3_certs_ro" {
         "s3:Get*"
       ],
       "Resource": [
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}/${replace(var.s3_bucket_prefix,"/^(\/)+|(\/)+$/","")}",
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}/${replace(var.s3_bucket_prefix,"/^(\/)+|(\/)+$/","")}/*"
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}/${replace(var.s3_bucket_prefix,"/^(/)+|(/)+$/","")}",
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}/${replace(var.s3_bucket_prefix,"/^(/)+|(/)+$/","")}/*"
       ]
     },
     {
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy" "s3_certs_ro" {
         "s3:List*"
       ],
       "Resource": [
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}"
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}"
       ]
     }
   ]

--- a/certs/templates/user_data.tpl
+++ b/certs/templates/user_data.tpl
@@ -1,6 +1,6 @@
 #cloud-config
 runcmd:
-  - echo "OPENVPN_CERT_SOURCE=s3://${replace(s3_bucket,"/(\/)+$/","")}/${replace(s3_bucket_prefix,"/^(\/)+|(\/)+$/","")}" > /etc/openvpn/get-openvpn-certs.env
+  - echo "OPENVPN_CERT_SOURCE=s3://${replace(s3_bucket,"/(/)+$/","")}/${replace(s3_bucket_prefix,"/^(/)+|(/)+$/","")}" > /etc/openvpn/get-openvpn-certs.env
   - echo "push \"route $(ip route get 8.8.8.8| grep src| sed 's/.*src \(.*\)$/\1/g') 255.255.255.255 net_gateway\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),1), 0)}  ${cidrnetmask(element(split(",",route_cidrs),1))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),2), 0)}  ${cidrnetmask(element(split(",",route_cidrs),2))}\"" >> /etc/openvpn/server.conf

--- a/examples/cert-gen/variables.tf
+++ b/examples/cert-gen/variables.tf
@@ -35,7 +35,7 @@ variable "region" {
 }
 
 variable "subnets" {
-  tpye        = "string"
+  type        = "string"
   description = "List of VPC subnets eligible for instance deployment"
 }
 

--- a/generate-certs/main.tf
+++ b/generate-certs/main.tf
@@ -36,8 +36,8 @@ resource "aws_iam_role_policy" "s3_certs_rw" {
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}",
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}/*"
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}",
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}/*"
       ]
     },
     {
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy" "s3_certs_rw" {
         "s3:List*"
       ],
       "Resource": [
-        "arn:aws:s3:::${replace(var.s3_bucket,"/(\/)+$/","")}"
+        "arn:aws:s3:::${replace(var.s3_bucket,"/(/)+$/","")}"
       ]
     }
   ]

--- a/generate-certs/templates/user_data.tpl
+++ b/generate-certs/templates/user_data.tpl
@@ -3,9 +3,9 @@ manage_etc_hosts: True
 
 runcmd:
   - echo "S3_REGION=\"${region}\"" > /etc/default/openvpn-cert-generator
-  - echo "S3_CERT_ROOT_PATH=\"s3://${replace(s3_bucket,"/(\/)+$/","")}/\"" >> /etc/default/openvpn-cert-generator
+  - echo "S3_CERT_ROOT_PATH=\"s3://${replace(s3_bucket,"/(/)+$/","")}/\"" >> /etc/default/openvpn-cert-generator
   - echo "KEY_SIZE=${cert_key_size}" >> /etc/default/openvpn-cert-generator
-  - echo "S3_DIR_OVERRIDE=\"${replace(s3_dir_override,"/^(\/)+|(\/)+$/","")}\"" >> /etc/default/openvpn-cert-generator
+  - echo "S3_DIR_OVERRIDE=\"${replace(s3_dir_override,"/^(/)+|(/)+$/","")}\"" >> /etc/default/openvpn-cert-generator
   - echo "KEY_CITY=\"${key_city}\"" >> /etc/default/openvpn-cert-generator
   - echo "KEY_ORG=\"${key_org}\"" >> /etc/default/openvpn-cert-generator
   - echo "KEY_EMAIL=\"${key_email}\"" >> /etc/default/openvpn-cert-generator

--- a/generate-certs/variables.tf
+++ b/generate-certs/variables.tf
@@ -51,7 +51,7 @@ variable "region" {
 }
 
 variable "subnet" {
-  tpye        = "string"
+  type        = "string"
   description = "VPC subnet to associate with the instance"
 }
 


### PR DESCRIPTION
Update modules to use terraform 0.8.x syntax where backslashes are ignored in variable interpolation.  This patch in not compatible with terraform versions < 0.8.0