### PR TITLE
DEVOPS-1218 fix permissions for openvpn

### DIFF
--- a/certs/templates/user_data.tpl
+++ b/certs/templates/user_data.tpl
@@ -6,6 +6,8 @@ runcmd:
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),2), 0)}  ${cidrnetmask(element(split(",",route_cidrs),2))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),3), 0)}  ${cidrnetmask(element(split(",",route_cidrs),3))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),4), 0)}  ${cidrnetmask(element(split(",",route_cidrs),4))}\"" >> /etc/openvpn/server.conf
+  - sed -i 's/\(ExecStartPost=.*chmod.*$\)/ExecStartPost=\/bin\/chown -R nobody:nogroup \/etc\/openvpn\n\1\n/g' /etc/systemd/system/get-openvpn-certs.service
+  - systemctl daemon-reload
   - systemctl start get-openvpn-certs
   - systemctl restart openvpn@server
   - systemctl restart iptables

--- a/certs/templates/user_data.tpl
+++ b/certs/templates/user_data.tpl
@@ -1,4 +1,6 @@
 #cloud-config
+## The sed and daemon-reload entries are temporary and will be removed once permission issue is handled on base AMI.
+## https://github.com/WhistleLabs/terraform-aws-openvpn/pull/2
 runcmd:
   - echo "OPENVPN_CERT_SOURCE=s3://${replace(s3_bucket,"/(/)+$/","")}/${replace(s3_bucket_prefix,"/^(/)+|(/)+$/","")}" > /etc/openvpn/get-openvpn-certs.env
   - echo "push \"route $(ip route get 8.8.8.8| grep src| sed 's/.*src \(.*\)$/\1/g') 255.255.255.255 net_gateway\"" >> /etc/openvpn/server.conf


### PR DESCRIPTION
DEVOPS-1218
Modified the systemd file to change the owner to nobody:nogroup so that a crl.pem change will not result in a hang on the server starting.

- Once merged with master will need to tag and associate tag in dependent projects. 