### PR TITLE
DEVOPS-1270: Add a different list of CIDRs for ICMP

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "cluster_allow_icmp_in" {
   from_port         = 0
   to_port           = 0
   protocol          = "icmp"
-  cidr_blocks       = ["${split(",",var.ssh_whitelist)}"]
+  cidr_blocks       = ["${split(",",var.icmp_whitelist)}"]
   security_group_id = "${module.cluster.sg_id}"
 }
 

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -86,3 +86,9 @@ variable "ssh_whitelist" {
   description = "Limit SSH access to the designated list of CIDRs"
   default     = "0.0.0.0/0"
 }
+
+variable "icmp_whitelist" {
+  type        = "string"
+  description = "Limit ICMP response to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
Allow the ability to ping from the office, but not ssh