### PR TITLE
DEVOPS-1296: fix IAM profile warnings

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -78,8 +78,8 @@ EOF
 
 ## Creates IAM instance profile
 resource "aws_iam_instance_profile" "profile" {
-  name  = "${var.stack_item_label}-${var.region}"
-  roles = ["${aws_iam_role.role.name}"]
+  name = "${var.stack_item_label}-${var.region}"
+  role = "${aws_iam_role.role.name}"
 }
 
 ## Create elastic load balancer security group and rules

--- a/generate-certs/main.tf
+++ b/generate-certs/main.tf
@@ -79,8 +79,8 @@ EOF
 
 ## Creates IAM instance profile
 resource "aws_iam_instance_profile" "profile" {
-  name  = "${var.stack_item_label}-${var.region}"
-  roles = ["${aws_iam_role.role.name}"]
+  name = "${var.stack_item_label}-${var.region}"
+  role = "${aws_iam_role.role.name}"
 }
 
 ## Creates security group rules


### PR DESCRIPTION
```
Warnings:

  * module.cert_generator.aws_iam_instance_profile.profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
```