### PR TITLE
DEVOPS-1692

### DIFF
--- a/generate-certs/outputs.tf
+++ b/generate-certs/outputs.tf
@@ -1,0 +1,5 @@
+# Outputs
+
+output "role_id_certgen" {
+  value = "${aws_iam_role.role.unique_id}"
+}


### PR DESCRIPTION
PR adds the cert-gen iam role id to the new outputs file so that it can be used in other stacks specifically to be added to the openvpn-config bucket policy. 